### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#The Consumer Dispatcher Project
+# The Consumer Dispatcher Project
 
 Consumer Dispatcher works as a proxy between [RabbitMQ](http://www.rabbitmq.com/) and your consumers. Let you scale out and maintain consumers easily.
 
@@ -57,4 +57,4 @@ It can work with all http-based interfaces written in any language.
 
 - Apache License, Version 2.0
 
-##There definitely are loooooooot of room to improve Consumer Dispatcher. Any suggestion would be appreciated . Thank you for your support!
+## There definitely are loooooooot of room to improve Consumer Dispatcher. Any suggestion would be appreciated . Thank you for your support!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
